### PR TITLE
Add Moose to prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,7 @@ file = lib/CHI/Memoize/Util.pm
 [Prereqs / RuntimeRequires]
 CHI = 0.47
 Hash::MoreUtils = 0
+Moose = 0
 
 [Prereqs / TestRequires]
 Test::Class::Most = 0


### PR DESCRIPTION
Add Moose to prereqs, Info.pm has `use Moose;` causing installation failures:

https://rt.cpan.org/Public/Bug/Display.html?id=97992
